### PR TITLE
added platforms to fix issue in Xcode archiving process

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,11 @@ import PackageDescription
 
 let package = Package(
     name: "FloatingLabelTextFieldSwiftUI",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_15),
+        .tvOS(.v13)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
Xcode is unable to complete the archive process due to many errors in the same pattern "Cannot find type '$' in scope'