### PR TITLE
Feature/multiline text

### DIFF
--- a/Example/FloatingLabelTextFieldSwiftUI.xcodeproj/project.pbxproj
+++ b/Example/FloatingLabelTextFieldSwiftUI.xcodeproj/project.pbxproj
@@ -476,7 +476,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = FloatingLabelTextFieldSwiftUI/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
@@ -492,7 +492,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = FloatingLabelTextFieldSwiftUI/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
@@ -515,7 +515,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -534,7 +534,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/FloatingLabelTextFieldSwiftUI.xcodeproj/project.pbxproj
+++ b/Example/FloatingLabelTextFieldSwiftUI.xcodeproj/project.pbxproj
@@ -476,7 +476,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = FloatingLabelTextFieldSwiftUI/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
@@ -492,7 +492,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = FloatingLabelTextFieldSwiftUI/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
@@ -515,6 +515,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -533,6 +534,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/FloatingLabelTextFieldSwiftUI/ContentView.swift
+++ b/Example/FloatingLabelTextFieldSwiftUI/ContentView.swift
@@ -26,6 +26,8 @@ struct ContentView: View {
     @State private var showDatePicker: Bool = false
     
     @State private var isPasswordShow: Bool = false
+
+    @State private var notes: String = ""
     
     private var selectedDate: Binding<Date> {
         Binding<Date>(get: { self.date}, set : {
@@ -105,6 +107,12 @@ struct ContentView: View {
             .keyboardType(.emailAddress)
             .modifier(ThemeTextField())
             
+
+            FloatingLabelTextField($notes, placeholder: "Notes", axis: .vertical)
+                .spaceBetweenTitleText(8.0)
+                .lineLimit(5)
+//                .frame(maxHeight: 200)
+
             FloatingLabelTextField($password, placeholder: "Password", editingChanged: { (isChanged) in
                 
             }) {
@@ -142,7 +150,7 @@ struct ContentView: View {
                 
             }) {
                 Text("Create")
-            }
+            }   
             .buttonStyle(CreateButtonStyle())
             Spacer()
         }

--- a/Example/FloatingLabelTextFieldSwiftUI/ContentView.swift
+++ b/Example/FloatingLabelTextFieldSwiftUI/ContentView.swift
@@ -111,7 +111,7 @@ struct ContentView: View {
             FloatingLabelTextField($notes, placeholder: "Notes", axis: .vertical)
                 .spaceBetweenTitleText(8.0)
                 .lineLimit(5)
-//                .frame(maxHeight: 200)
+                .frame(minHeight: 80)
 
             FloatingLabelTextField($password, placeholder: "Password", editingChanged: { (isChanged) in
                 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,9 @@ import PackageDescription
 let package = Package(
     name: "FloatingLabelTextFieldSwiftUI",
     platforms: [
-        .iOS(.v13),
-        .macOS(.v10_15),
-        .tvOS(.v13)
+        .iOS(.v16),
+        .macOS(.v13),
+        .tvOS(.v16)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,9 @@ import PackageDescription
 let package = Package(
     name: "FloatingLabelTextFieldSwiftUI",
     platforms: [
-        .iOS(.v16),
-        .macOS(.v13),
-        .tvOS(.v16)
+        .iOS(.v15),
+        .macOS(.v12),
+        .tvOS(.v15)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Sources/FloatingLabelTextFieldSwiftUI/FloatingLabelTextField.swift
+++ b/Sources/FloatingLabelTextFieldSwiftUI/FloatingLabelTextField.swift
@@ -9,13 +9,13 @@
 import SwiftUI
 
 //MARK: FloatingLabelTextField Style Protocol
-@available(iOS 16.0, *)
+@available(iOS 15.0, *)
 public protocol FloatingLabelTextFieldStyle {
     func body(content: FloatingLabelTextField) -> FloatingLabelTextField
 }
 
 //MARK: FloatingLabelTextField View
-@available(iOS 16.0, *)
+@available(iOS 15.0, *)
 public struct FloatingLabelTextField: View {
 
     //MARK: Binding Property
@@ -35,6 +35,7 @@ public struct FloatingLabelTextField: View {
     }
 
     @State var isShowError: Bool = false
+
     @FocusState fileprivate var isFocused: Bool
     @State private var textFieldHeight: CGFloat = 0.0
 
@@ -102,38 +103,66 @@ public struct FloatingLabelTextField: View {
                 .foregroundColor((self.currentError.condition || !notifier.isShowError) ? (isSelected ? notifier.selectedTextColor : notifier.textColor) : notifier.errorColor)
 
             } else {
-                TextField("", text: $textFieldValue.animation(), axis: axis)
-                .focused($isFocused)
-                .onChange(of: isFocused, perform: { (isChanged) in
-                    withAnimation {
-                        DispatchQueue.main.async {
-                            self.isSelected = isChanged
+                if #available(iOS 16.0, *) {
+                    TextField("", text: $textFieldValue.animation(), axis: axis)
+                        .focused($isFocused)
+                        .onChange(of: isFocused, perform: { (isChanged) in
+                            withAnimation {
+                                DispatchQueue.main.async {
+                                    self.isSelected = isChanged
+                                }
+                            }
+
+                            DispatchQueue.main.async {
+                                self.isShowError = self.notifier.isRequiredField
+                            }
+
+                            self.validtionChecker = self.currentError.condition
+                            self.editingChanged(isChanged)
+                            arrTextFieldEditActions = self.notifier.arrTextFieldEditActions
+                        })
+                        .onSubmit({
+                            self.isShowError = self.notifier.isRequiredField
+                            self.validtionChecker = self.currentError.condition
+                            self.commit()
+                            arrTextFieldEditActions = []
+                        })
+                        .lineLimit(notifier.lineLimit)
+                        .disabled(self.notifier.disabled)
+                        .allowsHitTesting(self.notifier.allowsHitTesting)
+                        .multilineTextAlignment(notifier.textAlignment)
+                        .font(notifier.font)
+                        .foregroundColor((self.currentError.condition || !notifier.isShowError) ? (isSelected ? notifier.selectedTextColor : notifier.textColor) : notifier.errorColor)
+                        .background(
+                            GeometryReader(content: set(geometry:))
+                        )
+                } else {
+                    TextField("", text: $textFieldValue.animation(), onEditingChanged: { (isChanged) in
+                        withAnimation {
+                            DispatchQueue.main.async {
+                                self.isSelected = isChanged
+                            }
                         }
-                    }
 
-                    DispatchQueue.main.async {
+                        DispatchQueue.main.async {
+                            self.isShowError = self.notifier.isRequiredField
+                        }
+
+                        self.validtionChecker = self.currentError.condition
+                        self.editingChanged(isChanged)
+                        arrTextFieldEditActions = self.notifier.arrTextFieldEditActions
+                    }, onCommit: {
                         self.isShowError = self.notifier.isRequiredField
-                    }
-
-                    self.validtionChecker = self.currentError.condition
-                    self.editingChanged(isChanged)
-                    arrTextFieldEditActions = self.notifier.arrTextFieldEditActions
-                })
-                .onSubmit({
-                    self.isShowError = self.notifier.isRequiredField
-                    self.validtionChecker = self.currentError.condition
-                    self.commit()
-                    arrTextFieldEditActions = []
-                })
-                .lineLimit(notifier.lineLimit)
-                .disabled(self.notifier.disabled)
-                .allowsHitTesting(self.notifier.allowsHitTesting)
-                .multilineTextAlignment(notifier.textAlignment)
-                .font(notifier.font)
-                .foregroundColor((self.currentError.condition || !notifier.isShowError) ? (isSelected ? notifier.selectedTextColor : notifier.textColor) : notifier.errorColor)
-                .background(
-                    GeometryReader(content: set(geometry:))
-                )
+                        self.validtionChecker = self.currentError.condition
+                        self.commit()
+                        arrTextFieldEditActions = []
+                    })
+                    .disabled(self.notifier.disabled)
+                    .allowsHitTesting(self.notifier.allowsHitTesting)
+                    .multilineTextAlignment(notifier.textAlignment)
+                    .font(notifier.font)
+                    .foregroundColor((self.currentError.condition || !notifier.isShowError) ? (isSelected ? notifier.selectedTextColor : notifier.textColor) : notifier.errorColor)
+                }
             }
         }
     }
@@ -203,7 +232,7 @@ public struct FloatingLabelTextField: View {
 }
 
 //MARK: FloatingLabelTextField Style Funcation
-@available(iOS 16.0, *)
+@available(iOS 15.0, *)
 extension FloatingLabelTextField {
     public func floatingStyle<S>(_ style: S) -> some View where S: FloatingLabelTextFieldStyle {
         return style.body(content: self)
@@ -211,7 +240,7 @@ extension FloatingLabelTextField {
 }
 
 //MARK: View Property Funcation
-@available(iOS 16.0, *)
+@available(iOS 15.0, *)
 extension FloatingLabelTextField {
     /// Sets the left view.
     public func leftView<LRView: View>(@ViewBuilder _ view: @escaping () -> LRView) -> Self {
@@ -227,7 +256,7 @@ extension FloatingLabelTextField {
 }
 
 //MARK: Text Property Funcation
-@available(iOS 16.0, *)
+@available(iOS 15.0, *)
 extension FloatingLabelTextField {
     /// Sets the alignment for text.
     public func textAlignment(_ alignment: TextAlignment) -> Self {
@@ -252,7 +281,10 @@ extension FloatingLabelTextField {
         notifier.allowsHitTesting = isAllowsHitTesting
         return self
     }
+}
 
+@available(iOS 16.0, *)
+extension FloatingLabelTextField {
     public func lineLimit(_ limit: Int) -> Self {
         notifier.lineLimit = limit
         return self
@@ -260,7 +292,7 @@ extension FloatingLabelTextField {
 }
 
 //MARK: Line Property Funcation
-@available(iOS 16.0, *)
+@available(iOS 15.0, *)
 extension FloatingLabelTextField {
     /// Sets the line height.
     public func lineHeight(_ height: CGFloat) -> Self {
@@ -288,7 +320,7 @@ extension FloatingLabelTextField {
 }
 
 //MARK: Title Property Funcation
-@available(iOS 16.0, *)
+@available(iOS 15.0, *)
 extension FloatingLabelTextField {
     /// Sets the title color.
     public func titleColor(_ color: Color) -> Self {
@@ -316,7 +348,7 @@ extension FloatingLabelTextField {
 }
 
 //MARK: Text Property Funcation
-@available(iOS 16.0, *)
+@available(iOS 15.0, *)
 extension FloatingLabelTextField {
     /// Sets the text color.
     public func textColor(_ color: Color) -> Self {
@@ -338,7 +370,7 @@ extension FloatingLabelTextField {
 }
 
 //MARK: Placeholder Property Funcation
-@available(iOS 16.0, *)
+@available(iOS 15.0, *)
 extension FloatingLabelTextField {
     /// Sets the placeholder color.
     public func placeholderColor(_ color: Color) -> Self {
@@ -354,7 +386,7 @@ extension FloatingLabelTextField {
 }
 
 //MARK: Error Property Funcation
-@available(iOS 16.0, *)
+@available(iOS 15.0, *)
 extension FloatingLabelTextField {
     /// Sets the is show error message.
     public func isShowError(_ show: Bool) -> Self {
@@ -389,7 +421,7 @@ extension FloatingLabelTextField {
 }
 
 //MARK: Text Field Editing Funcation
-@available(iOS 16.0, *)
+@available(iOS 15.0, *)
 extension FloatingLabelTextField {
     /// Disable text field editing action. Like cut, copy, past, all etc.
     public func addDisableEditingAction(_ actions: [TextFieldEditActions]) -> Self {
@@ -399,7 +431,7 @@ extension FloatingLabelTextField {
 }
 
 //MARK: Animation Style Funcation
-@available(iOS 16.0, *)
+@available(iOS 15.0, *)
 extension FloatingLabelTextField {
     /// Enable the placeholder label when the textfield is focused.
     public func enablePlaceholderOnFocus(_ isEanble: Bool) -> Self {

--- a/Sources/FloatingLabelTextFieldSwiftUI/ObservableObject/ObservableObject.swift
+++ b/Sources/FloatingLabelTextFieldSwiftUI/ObservableObject/ObservableObject.swift
@@ -40,7 +40,7 @@ class FloatingLabelTextFieldNotifier: ObservableObject {
     @Published var placeholderFont: Font = .system(size: 15)
     
     //MARK: Other Properties
-    @Published var spaceBetweenTitleText: Double = 15
+    @Published var spaceBetweenTitleText: Double = 30
     @Published var isSecureTextEntry: Bool = false
     @Published var disabled: Bool = false
     @Published var allowsHitTesting: Bool = true

--- a/Sources/FloatingLabelTextFieldSwiftUI/ObservableObject/ObservableObject.swift
+++ b/Sources/FloatingLabelTextFieldSwiftUI/ObservableObject/ObservableObject.swift
@@ -33,6 +33,7 @@ class FloatingLabelTextFieldNotifier: ObservableObject {
     @Published var textColor: Color = .black
     @Published var selectedTextColor: Color = .blue
     @Published var font: Font = .system(size: 15)
+    @Published var lineLimit: Int = 1
     
     //MARK: Placeholder Properties
     @Published var placeholderColor: Color = .gray


### PR DESCRIPTION
Wanted to have multiline text. In order to do that, had to use iOS 16 available init with axis parameter.
It also changes how focus is managed, by forcing to use @FocusState - which is available from iOS 15 and up, as a property wrapper. Since it is needed for a stored property, can't use `@available` annotation on it.
So had to bump min iOS version for the lib to iOS 15.

Also had to deal with `maxHeight: infinity` breaking the layout - wanted to have multiline field expand as more lines are used; instead of a big field from the start.

Let me know if you are willing to accept the change; or have any other ideas to keep it iOS 13 compatible.